### PR TITLE
Use default snappy settings

### DIFF
--- a/reynolds/dict/templates/snappyHexMeshDict.foam
+++ b/reynolds/dict/templates/snappyHexMeshDict.foam
@@ -42,14 +42,14 @@ castellatedMeshControls
     // If local number of cells is >= maxLocalCells on any processor
     // switches from from refinement followed by balancing
     // (current method) to (weighted) balancing before refinement.
-    maxLocalCells 0;
+    maxLocalCells 100000;
 
     // Overall cell limit (approximately). Refinement will stop immediately
     // upon reaching this number so a refinement level might not complete.
     // Note that this is the number of cells before removing the part which
     // is not 'visible' from the keepPoint. The final number of cells might
     // actually be a lot less.
-    maxGlobalCells 0;
+    maxGlobalCells 2000000;
 
     // The surface refinement loop might spend lots of iterations refining just a
     // few cells. This setting will cause refinement to stop if <= minimumRefine
@@ -131,7 +131,7 @@ castellatedMeshControls
     // Whether any faceZones (as specified in the refinementSurfaces)
     // are only on the boundary of corresponding cellZones or also allow
     // free-standing zone faces. Not used if there are no faceZones.
-    allowFreeStandingZoneFaces false;
+    allowFreeStandingZoneFaces true;
 }
 
 
@@ -141,7 +141,7 @@ snapControls
 {
     //- Number of patch smoothing iterations before finding correspondence
     //  to surface
-    nSmoothPatch 0;
+    nSmoothPatch 3;
 
     //- Relative distance for points to be attracted by surface feature point
     //  or edge. True distance is this factor times local
@@ -149,28 +149,28 @@ snapControls
     tolerance 1.0; // 1.0;
 
     //- Number of mesh displacement relaxation iterations.
-    nSolveIter 0;
+    nSolveIter 300;
 
     //- Maximum number of snapping relaxation iterations. Should stop
     //  before upon reaching a correct mesh.
-    nRelaxIter 0;
+    nRelaxIter 5;
 
     // Feature snapping
 
         // Number of feature edge snapping iterations.
         // Leave out altogether to disable.
-        nFeatureSnapIter 0;
+        nFeatureSnapIter 10;
 
         // Detect (geometric only) features by sampling the surface
         // (default=false).
         implicitFeatureSnap false;
 
         // Use castellatedMeshControls::features (default = true)
-        explicitFeatureSnap false;
+        explicitFeatureSnap true;
 
         // Detect features between multiple surfaces
         // (only for explicitFeatureSnap, default = false)
-        multiRegionFeatureSnap false;
+        multiRegionFeatureSnap true;
 }
 
 
@@ -194,12 +194,12 @@ addLayersControls
     // is the thickness of the layer furthest away from the wall.
     // Relative to undistorted size of cell outside layer.
     // See relativeSizes parameter.
-    finalLayerThickness 0;
+    finalLayerThickness 0.3;
 
     // Minimum thickness of cell layer. If for any reason layer
     // cannot be above minThickness do not add layer.
     // Relative to undistorted size of cell outside layer.
-    minThickness 0;
+    minThickness 0.25;
 
     // If points get not extruded do nGrow layers of connected faces that are
     // also not grown. This helps convergence of the layer addition process
@@ -211,31 +211,31 @@ addLayersControls
 
     // When not to extrude surface. 0 is flat surface, 90 is when two faces
     // are perpendicular
-    featureAngle 0;
+    featureAngle 30;
 
     // Maximum number of snapping relaxation iterations. Should stop
     // before upon reaching a correct mesh.
-    nRelaxIter 0;
+    nRelaxIter 5;
 
     // Number of smoothing iterations of surface normals
-    nSmoothSurfaceNormals 0;
+    nSmoothSurfaceNormals 1;
 
     // Number of smoothing iterations of interior mesh movement direction
-    nSmoothNormals 0;
+    nSmoothNormals 3;
 
     // Smooth layer thickness over surface patches
-    nSmoothThickness 0;
+    nSmoothThickness 10;
 
     // Stop layer growth on highly warped cells
-    maxFaceThicknessRatio 0;
+    maxFaceThicknessRatio 0.5;
 
     // Reduce layer growth where ratio thickness to medial
     // distance is large
-    maxThicknessToMedialRatio 0;
+    maxThicknessToMedialRatio 0.3;
 
     // Angle used to pick up medial axis points
     // Note: changed(corrected) w.r.t 17x! 90 degrees corresponds to 130 in 17x.
-    minMedianAxisAngle 0;
+    minMedianAxisAngle 90;
 
 
     // Create buffer region for new layer terminations
@@ -245,7 +245,12 @@ addLayersControls
     // Overall max number of layer addition iterations. The mesher will exit
     // if it reaches this number of iterations; possibly with an illegal
     // mesh.
-    nLayerIter 0;
+    nLayerIter 50;
+
+    // Max number of iterations after which relaxed meshQuality controls
+    // get used. Up to nRelaxIter it uses the settings in meshQualityControls,
+    // after nRelaxIter it uses the values in meshQualityControls::relaxed.
+    nRelaxedIter 20;
 }
 
 
@@ -258,18 +263,18 @@ meshQualityControls
     maxNonOrtho 65;
 
     //- Max skewness allowed. Set to <0 to disable.
-    maxBoundarySkewness 0;
-    maxInternalSkewness 0;
+    maxBoundarySkewness 20;
+    maxInternalSkewness 4;
 
-    //- Max concaveness allowed. Is angle (in degrees) below which concavity
+    //- Max concavens allowed. Is angle (in degrees) below which concavity
     //  is allowed. 0 is straight face, <0 would be convex face.
     //  Set to 180 to disable.
-    maxConcave 0;
+    maxConcave 80;
 
     //- Minimum pyramid volume. Is absolute volume of cell pyramid.
     //  Set to a sensible fraction of the smallest cell volume expected.
     //  Set to very negative number (e.g. -1E30) to disable.
-    minVol 0;
+    minVol 1e13;
 
     //- Minimum quality of the tet formed by the face-centre
     //  and variable base point minimum decomposition triangles and
@@ -279,42 +284,42 @@ meshQualityControls
     //     <0 = inside out tet,
     //      0 = flat tet
     //      1 = regular tet
-    minTetQuality 0; // 1e-30;
+    minTetQuality 1e-15; // 1e-30;
 
     //- Minimum face area. Set to <0 to disable.
-    minArea 0;
+    minArea -1;
 
     //- Minimum face twist. Set to <-1 to disable. dot product of face normal
     //  and face centre triangles normal
-    minTwist 0;
+    minTwist 0.02;
 
     //- Minimum normalised cell determinant
     //  1 = hex, <= 0 = folded or flattened illegal cell
-    minDeterminant 0;
+    minDeterminant 0.001;
 
     //- minFaceWeight (0 -> 0.5)
-    minFaceWeight 0;
+    minFaceWeight 0.05;
 
     //- minVolRatio (0 -> 1)
-    minVolRatio 0;
+    minVolRatio 0.01;
 
     //must be >0 for Fluent compatibility
-    minTriangleTwist 0;
+    minTriangleTwist -1;
 
 
     // Advanced
 
     //- Number of error distribution iterations
-    nSmoothScale 0;
+    nSmoothScale 4;
     //- Amount to scale back displacement at error points
-    errorReduction 0;
+    errorReduction 0.75;
 
     // Optional : some meshing phases allow usage of relaxed rules.
     // See e.g. addLayersControls::nRelaxedIter.
     relaxed
     {
         //- Maximum non-orthogonality allowed. Set to 180 to disable.
-        maxNonOrtho 0;
+        maxNonOrtho 75;
     }
 }
 


### PR DESCRIPTION
Use default settings from flange case in openFoam sources and meshQualityControls in etc.